### PR TITLE
fix .gitignore to allow netdiff/env dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ venv.bak/
 
 # Installation path for CVP example
 examples/evpn-l3ls-cvp-deployment/collections
+
+# exclude netdiff env folder from gitignore
+!**/post_validation/netdiff/env

--- a/demo/emea-2020-ansible-cvp-automation/post_validation/netdiff/env/__init__.py
+++ b/demo/emea-2020-ansible-cvp-automation/post_validation/netdiff/env/__init__.py
@@ -1,0 +1,5 @@
+from pkgutil import iter_modules
+from importlib import import_module
+
+for _, module_name, _ in iter_modules(__path__):
+    import_module('.' + module_name, package=__name__)

--- a/demo/emea-2020-ansible-cvp-automation/post_validation/netdiff/env/avd/__init__.py
+++ b/demo/emea-2020-ansible-cvp-automation/post_validation/netdiff/env/avd/__init__.py
@@ -1,0 +1,5 @@
+from pkgutil import iter_modules
+from importlib import import_module
+
+for _, module_name, _ in iter_modules(__path__):
+    import_module('.' + module_name, package=__name__)

--- a/demo/emea-2020-ansible-cvp-automation/post_validation/netdiff/env/avd/current/__init__.py
+++ b/demo/emea-2020-ansible-cvp-automation/post_validation/netdiff/env/avd/current/__init__.py
@@ -1,0 +1,5 @@
+from pkgutil import iter_modules
+from importlib import import_module
+
+for _, module_name, _ in iter_modules(__path__):
+    import_module('.' + module_name, package=__name__)

--- a/demo/emea-2020-ansible-cvp-automation/post_validation/netdiff/env/avd/current/bgp.py
+++ b/demo/emea-2020-ansible-cvp-automation/post_validation/netdiff/env/avd/current/bgp.py
@@ -1,0 +1,41 @@
+import netdiff
+import sys
+
+def from_dut(in_data):
+
+    bgp_peer_dict = dict()
+
+    for hostname, details in in_data['duts'].items():
+
+        if hostname not in bgp_peer_dict.keys():
+            bgp_peer_dict.update({hostname: {
+                'underlay': dict(),
+                'evpn': dict()
+            }})
+
+        if 'default' in details['show ip bgp summary']['vrfs'].keys():
+
+            # add underlay peers
+            for peer_ip, peer_details in details['show ip bgp summary']['vrfs']['default']['peers'].items():
+                peer_state = peer_details['peerState']
+                bgp_peer_dict[hostname]['underlay'].update({peer_ip: {'state': peer_state}})
+
+            # add EVPN
+            for peer_ip, peer_details in details['show bgp evpn summary']['vrfs']['default']['peers'].items():
+                peer_state = peer_details['peerState']
+                bgp_peer_dict[hostname]['evpn'].update({peer_ip: {'state': peer_state}})
+
+    return bgp_peer_dict
+
+
+if __name__ == "__main__":
+    eval_check_list = [  # list all functions allowed for eval() here
+        'from_dut',
+    ]
+    args = netdiff.tools.parsers.src_dst_parser()
+    in_data = netdiff.read._from(args.src_format, args.src_filename)
+    if args.case in eval_check_list:
+        out_data = eval(args.case + f'({in_data})')
+        netdiff.write.to_file(args.dst_filename, args.dst_format, out_data)
+    else:
+        sys.exit(f'ERROR: Specified case {args.case} is not supported!')

--- a/demo/emea-2020-ansible-cvp-automation/post_validation/netdiff/env/avd/current/environment.py
+++ b/demo/emea-2020-ansible-cvp-automation/post_validation/netdiff/env/avd/current/environment.py
@@ -1,0 +1,31 @@
+import netdiff
+import sys
+
+def from_dut(in_data):
+
+    platform_state_dict = dict()
+    for hostname, details in in_data['duts'].items():
+        platform_state_dict.update({
+            hostname: {
+                'cpuInfo': {
+                    'idle': details['show processes top once']['cpuInfo']['%Cpu(s)']['idle']
+                }
+            }
+        })
+
+    return platform_state_dict
+
+if __name__ == "__main__":
+    eval_check_list = [  # list all functions allowed for eval() here
+        'from_dut',
+    ]
+    args = netdiff.tools.parsers.src_dst_parser()
+    in_data = netdiff.read._from(args.src_format, args.src_filename)
+    if args.case in eval_check_list:
+        if not isinstance(in_data, str):
+            out_data = eval(args.case + f'({in_data})')
+        else:
+            out_data = eval(args.case + f'("{in_data}")')
+        netdiff.write.to_file(args.dst_filename, args.dst_format, out_data)
+    else:
+        sys.exit(f'ERROR: Specified case {args.case} is not supported!')

--- a/demo/emea-2020-ansible-cvp-automation/post_validation/netdiff/env/avd/current/mlag.py
+++ b/demo/emea-2020-ansible-cvp-automation/post_validation/netdiff/env/avd/current/mlag.py
@@ -1,0 +1,49 @@
+import netdiff
+import sys
+
+
+def mlag_status_from_dut(in_data):
+
+    mlag_status_dict = dict()
+
+    for hostname, d in in_data['duts'].items():
+
+        mlag = d['show mlag detail']
+        if 'domainId' in mlag.keys():
+            try:
+                mlag_status_dict.update({
+                    hostname: {
+                        'configSanity': mlag['configSanity'],
+                        'detail': {
+                            'mlagPorts': {
+                                'Inactive': mlag['mlagPorts']['Inactive'],
+                                'Active-partial': mlag['mlagPorts']['Active-partial'],
+                                'Disabled': mlag['mlagPorts']['Disabled']
+                            },
+                            'negStatus': mlag['negStatus'],
+                            'peerLinkStatus': mlag['peerLinkStatus'],
+                            'portsErrdisabled': mlag['portsErrdisabled'],
+                            'state': mlag['state']
+                        }
+                    }
+                })
+            except Exception as _:
+                pass
+
+    return mlag_status_dict
+
+
+if __name__ == "__main__":
+    eval_check_list = [  # list all functions allowed for eval() here
+        'mlag_status_from_dut',
+    ]
+    args = netdiff.tools.parsers.src_dst_parser()
+    in_data = netdiff.read._from(args.src_format, args.src_filename)
+    if args.case in eval_check_list:
+        if not isinstance(in_data, str):
+            out_data = eval(args.case + f'({in_data})')
+        else:
+            out_data = eval(args.case + f'("{in_data}")')
+        netdiff.write.to_file(args.dst_filename, args.dst_format, out_data)
+    else:
+        sys.exit(f'ERROR: Specified case {args.case} is not supported!')

--- a/demo/emea-2020-ansible-cvp-automation/post_validation/netdiff/env/avd/current/port_status.py
+++ b/demo/emea-2020-ansible-cvp-automation/post_validation/netdiff/env/avd/current/port_status.py
@@ -1,0 +1,53 @@
+import netdiff
+import sys
+
+
+def port_channel_status_from_dut(in_data):
+
+    port_channel_status = dict()
+
+    for hostname, d in in_data['duts'].items():
+
+        if 'portChannels' in d['show port-channel summary'].keys():
+            if len(d['show port-channel summary']['portChannels']):
+                port_channel_status.update({
+                    hostname: {
+                        'portChannels': dict()
+                    }
+                })
+                for po_name, po_status in d['show port-channel summary']['portChannels'].items():
+                    port_channel_status[hostname]['portChannels'].update({
+                        po_name: {
+                            'linkState': 'up'
+                        }
+                    })
+                    for eth_name, eth_status in po_status['ports'].items():
+                        if 'PeerEthernet' not in eth_name:
+                            port_channel_status[hostname]['portChannels'][po_name].update({
+                                        'ports': {
+                                            eth_name: {
+                                                'lacpMisconfig': eth_status['lacpMisconfig'],
+                                                'lagMember': eth_status['lagMember'],
+                                                'linkDown': eth_status['linkDown'],
+                                                'suspended': eth_status['suspended']
+                                            }
+                                        }
+                                    })
+
+    return port_channel_status
+
+
+if __name__ == "__main__":
+    eval_check_list = [  # list all functions allowed for eval() here
+        'port_channel_status_from_dut',
+    ]
+    args = netdiff.tools.parsers.src_dst_parser()
+    in_data = netdiff.read._from(args.src_format, args.src_filename)
+    if args.case in eval_check_list:
+        if not isinstance(in_data, str):
+            out_data = eval(args.case + f'({in_data})')
+        else:
+            out_data = eval(args.case + f'("{in_data}")')
+        netdiff.write.to_file(args.dst_filename, args.dst_format, out_data)
+    else:
+        sys.exit(f'ERROR: Specified case {args.case} is not supported!')

--- a/demo/emea-2020-ansible-cvp-automation/post_validation/netdiff/env/avd/current/topology.py
+++ b/demo/emea-2020-ansible-cvp-automation/post_validation/netdiff/env/avd/current/topology.py
@@ -1,0 +1,58 @@
+import netdiff
+import sys
+
+def from_dut(in_data):
+
+    topology_dict = dict()
+    for hostname, details in in_data['duts'].items():
+        for peer in details['show lldp neighbors']['lldpNeighbors']:
+            if 'Management1' not in peer['port']: # ignore LLDP on Ma1
+                new_peer_entry = {
+                    peer['port']: {
+                        'neighbor_port_name': peer['neighborPort'],
+                        'neighbor_hostname': peer['neighborDevice']
+                    }
+                }
+                if hostname in topology_dict.keys():
+                    topology_dict[hostname].update(new_peer_entry)
+                else:
+                    topology_dict.update({hostname: new_peer_entry})
+    
+    return topology_dict
+
+def from_dut_no_localhost(in_data):
+    # build network topology, but exclude `localhost` neigbors
+    topology_dict = dict()
+    for hostname, details in in_data['duts'].items():
+        for peer in details['show lldp neighbors']['lldpNeighbors']:
+            if ('localhost' not in peer['neighborDevice']) and (
+                'Management1' not in peer['port']):  # just for demo, find better way in prod
+                new_peer_entry = {
+                    peer['port']: {
+                        'neighbor_port_name': peer['neighborPort'],
+                        'neighbor_hostname': peer['neighborDevice']
+                    }
+                }
+                if hostname in topology_dict.keys():
+                    topology_dict[hostname].update(new_peer_entry)
+                else:
+                    topology_dict.update({hostname: new_peer_entry})
+
+    return topology_dict
+
+
+if __name__ == "__main__":
+    eval_check_list = [  # list all functions allowed for eval() here
+        'from_dut',
+        'from_dut_no_localhost',
+    ]
+    args = netdiff.tools.parsers.src_dst_parser()
+    in_data = netdiff.read._from(args.src_format, args.src_filename)
+    if args.case in eval_check_list:
+        if not isinstance(in_data, str):
+            out_data = eval(args.case + f'({in_data})')
+        else:
+            out_data = eval(args.case + f'("{in_data}")')
+        netdiff.write.to_file(args.dst_filename, args.dst_format, out_data)
+    else:
+        sys.exit(f'ERROR: Specified case {args.case} is not supported!')

--- a/demo/emea-2020-ansible-cvp-automation/post_validation/netdiff/env/avd/intended/__init__.py
+++ b/demo/emea-2020-ansible-cvp-automation/post_validation/netdiff/env/avd/intended/__init__.py
@@ -1,0 +1,5 @@
+from pkgutil import iter_modules
+from importlib import import_module
+
+for _, module_name, _ in iter_modules(__path__):
+    import_module('.' + module_name, package=__name__)

--- a/demo/emea-2020-ansible-cvp-automation/post_validation/netdiff/env/avd/intended/bgp.py
+++ b/demo/emea-2020-ansible-cvp-automation/post_validation/netdiff/env/avd/intended/bgp.py
@@ -1,0 +1,43 @@
+import netdiff
+import sys
+
+def from_struct_config(structured_configs_dir):
+
+    bgp_peer_dict = dict()
+    struct_config_data = netdiff.read.yamls_from_dir(structured_configs_dir)
+    for hostname, struct_config in struct_config_data.items():
+        bgp_peer_dict.update({
+            hostname: {
+                'underlay': dict(),
+                'evpn': dict()
+            }
+        })
+        if 'router_bgp' in struct_config.keys():
+            for bgp_peer_ip, bgp_peer_group_dict in struct_config['router_bgp']['neighbors'].items():
+                peer_group_name = bgp_peer_group_dict['peer_group']
+                if (peer_group_name == 'IPv4-UNDERLAY-PEERS') or (peer_group_name == 'MLAG-IPv4-UNDERLAY-PEER'):
+                    bgp_peer_dict[hostname]['underlay'].update({
+                        bgp_peer_ip: {'state': 'Established'}  # asn not supported due to listen-range
+                    })
+                elif peer_group_name == 'EVPN-OVERLAY-PEERS':
+                    bgp_peer_dict[hostname]['evpn'].update({
+                        bgp_peer_ip: {'state': 'Established'}  # asn not supported due to listen-range
+                    })
+
+    return bgp_peer_dict
+
+
+if __name__ == "__main__":
+    eval_check_list = [  # list all functions allowed for eval() here
+        'from_struct_config',
+    ]
+    args = netdiff.tools.parsers.src_dst_parser()
+    in_data = netdiff.read._from(args.src_format, args.src_filename)
+    if args.case in eval_check_list:
+        if not isinstance(in_data, str):
+            out_data = eval(args.case + f'({in_data})')
+        else:
+            out_data = eval(args.case + f'("{in_data}")')
+        netdiff.write.to_file(args.dst_filename, args.dst_format, out_data)
+    else:
+        sys.exit(f'ERROR: Specified case {args.case} is not supported!')

--- a/demo/emea-2020-ansible-cvp-automation/post_validation/netdiff/env/avd/intended/environment.py
+++ b/demo/emea-2020-ansible-cvp-automation/post_validation/netdiff/env/avd/intended/environment.py
@@ -1,0 +1,37 @@
+import netdiff
+import sys
+
+
+def cpu_from_csv_inventory(in_data):
+    # defines expected CPU threshold for every switch in inventory
+    platform_state_dict = dict()
+    for row in in_data:
+        if row['Node'] not in platform_state_dict.keys():
+            platform_state_dict.update({
+                row['Node']: {
+                    'cpuInfo': {
+                        'idle': {
+                            '__comparison_mode': 'ge',  # less or equal
+                            '__ref_value': 30  # adjust to higher value for demo if required
+                        }
+                    }
+                }
+            })
+
+    return platform_state_dict
+
+
+if __name__ == "__main__":
+    eval_check_list = [  # list all functions allowed for eval() here
+        'cpu_from_csv_inventory',
+    ]
+    args = netdiff.tools.parsers.src_dst_parser()
+    in_data = netdiff.read._from(args.src_format, args.src_filename)
+    if args.case in eval_check_list:
+        if not isinstance(in_data, str):
+            out_data = eval(args.case + f'({in_data})')
+        else:
+            out_data = eval(args.case + f'("{in_data}")')
+        netdiff.write.to_file(args.dst_filename, args.dst_format, out_data)
+    else:
+        sys.exit(f'ERROR: Specified case {args.case} is not supported!')

--- a/demo/emea-2020-ansible-cvp-automation/post_validation/netdiff/env/avd/intended/mlag.py
+++ b/demo/emea-2020-ansible-cvp-automation/post_validation/netdiff/env/avd/intended/mlag.py
@@ -1,0 +1,45 @@
+import netdiff
+import sys
+
+def from_struct_config(structured_configs_dir):
+
+    mlag_state_dict = dict()
+    struct_config_data = netdiff.read.yamls_from_dir(structured_configs_dir)
+    for hostname, struct_config in struct_config_data.items():
+        if isinstance(struct_config, dict):
+            if 'leaf_mlag' in struct_config.keys():
+                if struct_config['leaf_mlag']:
+                    mlag_state_dict.update({
+                        hostname: {
+                            'configSanity': 'consistent',
+                            'detail': {
+                                'mlagPorts': {
+                                    'Inactive': 0,
+                                    'Active-partial': 0,
+                                    'Disabled': 0,
+                                },
+                                'negStatus': 'connected',
+                                'peerLinkStatus': 'up',
+                                'portsErrdisabled': False,
+                                'state': 'active'
+                            }
+                        }
+                    })
+
+    return mlag_state_dict
+
+
+if __name__ == "__main__":
+    eval_check_list = [  # list all functions allowed for eval() here
+        'from_struct_config',
+    ]
+    args = netdiff.tools.parsers.src_dst_parser()
+    in_data = netdiff.read._from(args.src_format, args.src_filename)
+    if args.case in eval_check_list:
+        if not isinstance(in_data, str):
+            out_data = eval(args.case + f'({in_data})')
+        else:
+            out_data = eval(args.case + f'("{in_data}")')
+        netdiff.write.to_file(args.dst_filename, args.dst_format, out_data)
+    else:
+        sys.exit(f'ERROR: Specified case {args.case} is not supported!')

--- a/demo/emea-2020-ansible-cvp-automation/post_validation/netdiff/env/avd/intended/port_status.py
+++ b/demo/emea-2020-ansible-cvp-automation/post_validation/netdiff/env/avd/intended/port_status.py
@@ -1,0 +1,49 @@
+import netdiff
+import sys
+
+def port_channel_from_struct_cfg(structured_configs_dir):
+    expected_port_channel_status = dict()
+    struct_config_data = netdiff.read.yamls_from_dir(structured_configs_dir)
+    for hostname, struct_config in struct_config_data.items():
+        if isinstance(struct_config, dict):
+            if 'port_channel_interfaces' in struct_config.keys():
+                expected_port_channel_status.update({
+                    hostname: {'portChannels': dict()},
+                })
+                for port_channel_name in struct_config['port_channel_interfaces'].keys():
+                    expected_port_channel_status[hostname]['portChannels'].update({
+                        port_channel_name: {
+                            'linkState': 'up'
+                        }
+                    })
+            if 'ethernet_interfaces' in struct_config.keys():
+                for eth_name, eth_cfg in struct_config['ethernet_interfaces'].items():
+                    if isinstance(eth_cfg, dict):
+                        if 'channel_group' in eth_cfg.keys():
+                            port_channel_name = 'Port-Channel{}'.format(eth_cfg['channel_group']['id'])
+                            expected_port_channel_status[hostname]['portChannels'][port_channel_name].update({
+                                'ports': {
+                                    eth_name: {
+                                        'lacpMisconfig': {'status': 'bundled'},
+                                        'lagMember': True,
+                                        'linkDown': False,
+                                        'suspended': False
+                                    }
+                                }
+                            })
+    return expected_port_channel_status
+
+if __name__ == "__main__":
+    eval_check_list = [  # list all functions allowed for eval() here
+        'port_channel_from_struct_cfg',
+    ]
+    args = netdiff.tools.parsers.src_dst_parser()
+    in_data = netdiff.read._from(args.src_format, args.src_filename)
+    if args.case in eval_check_list:
+        if not isinstance(in_data, str):
+            out_data = eval(args.case + f'({in_data})')
+        else:
+            out_data = eval(args.case + f'("{in_data}")')
+        netdiff.write.to_file(args.dst_filename, args.dst_format, out_data)
+    else:
+        sys.exit(f'ERROR: Specified case {args.case} is not supported!')

--- a/demo/emea-2020-ansible-cvp-automation/post_validation/netdiff/env/avd/intended/topology.py
+++ b/demo/emea-2020-ansible-cvp-automation/post_validation/netdiff/env/avd/intended/topology.py
@@ -1,0 +1,59 @@
+import netdiff
+import sys
+
+def from_csv_doc(in_data):
+    # translate CSV topology doc into expected topology YAML
+
+    fabric_topology_csv_row_list = in_data
+    topology_dict = dict()
+    for row in fabric_topology_csv_row_list:
+        new_peer_entry = {
+            row['Node Interface']: {
+                'neighbor_port_name': row['Peer Interface'],
+                'neighbor_hostname': row['Peer']
+            }
+        }
+        if row['Node'] in topology_dict.keys():
+            topology_dict[row['Node']].update(new_peer_entry)
+        else:
+            topology_dict.update({row['Node']: new_peer_entry})
+
+    return topology_dict
+
+
+def from_csv_doc_without_servers(in_data):
+    # translate CSV topology doc into expected topology YAML, but exclude servers
+
+    fabric_topology_csv_row_list = in_data
+    topology_dict = dict()
+    for row in fabric_topology_csv_row_list:
+        if 'server' not in row['Peer']:  # just for demo, find better way in prod
+            new_peer_entry = {
+                row['Node Interface']: {
+                    'neighbor_port_name': row['Peer Interface'],
+                    'neighbor_hostname': row['Peer']
+                }
+            }
+            if row['Node'] in topology_dict.keys():
+                topology_dict[row['Node']].update(new_peer_entry)
+            else:
+                topology_dict.update({row['Node']: new_peer_entry})
+
+    return topology_dict
+    
+
+if __name__ == "__main__":
+    eval_check_list = [  # list all functions allowed for eval() here
+        'from_csv_doc',
+        'from_csv_doc_without_servers',
+    ]
+    args = netdiff.tools.parsers.src_dst_parser()
+    in_data = netdiff.read._from(args.src_format, args.src_filename)
+    if args.case in eval_check_list:
+        if not isinstance(in_data, str):
+            out_data = eval(args.case + f'({in_data})')
+        else:
+            out_data = eval(args.case + f'("{in_data}")')
+        netdiff.write.to_file(args.dst_filename, args.dst_format, out_data)
+    else:
+        sys.exit(f'ERROR: Specified case {args.case} is not supported!')


### PR DESCRIPTION
Some post validation code was missing in the latest commit due to .gitignore filtering post_validation/netdiff/env directory. This pull request contains missing files and .gitignore update.