### PR TITLE
Build: Detach GH pgaes publish from GH username

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -26,4 +26,6 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
             github_token: ${{ secrets.GITHUB_TOKEN }}
+            user_name: 'github-actions[bot]'
+            user_email: 'github-actions[bot]@users.noreply.github.com'
             publish_dir: ./site


### PR DESCRIPTION
Configure action to not use my username in commit history when publishing to GH
page branch

Since GH page branch is only populated by GH action and it is only for git
history, it is not required to use existing email
